### PR TITLE
Fix for IE : event.dataTransfer.setData

### DIFF
--- a/src/Ractive-decorators-sortable.js
+++ b/src/Ractive-decorators-sortable.js
@@ -142,7 +142,7 @@
 			throw new Error( errorMessage );
 		}
 
-		event.dataTransfer.setData( 'foo', true ); // enables dragging in FF. go figure
+		event.dataTransfer.setData( 'text', 'foobar' ); // enables dragging in FF. go figure
 
 		// keep a reference to the Ractive instance that 'owns' this data and this element
 		ractive = storage.root;


### PR DESCRIPTION
IE is a bit picky with dataTransfer.setData and allows only certain kind of format, not 'foo', breaking the whole D&D code. This fixes it.
http://msdn.microsoft.com/en-us/library/ie/ms536744%28v=vs.85%29.aspx
