### PR TITLE
Forgot to return the result of factory()

### DIFF
--- a/src/Ractive-decorators-sortable.js
+++ b/src/Ractive-decorators-sortable.js
@@ -64,7 +64,7 @@ var sortableDecorator = (function ( global, factory ) {
 
 	// Common JS (i.e. browserify) environment
 	if ( typeof module !== 'undefined' && module.exports && typeof require === 'function' ) {
-		factory( require( 'Ractive' ) );
+		return factory( require( 'Ractive' ) );
 	}
 
 	// AMD?
@@ -199,10 +199,10 @@ var sortableDecorator = (function ( global, factory ) {
 
 	Ractive.decorators.sortable = sortable;
 	
-	return sortable
+	return sortable;
 }));
 
 // Common JS (i.e. browserify) environment
 if ( typeof module !== 'undefined' && module.exports) {
-	module.exports = sortableDecorator
+	module.exports = sortableDecorator;
 }


### PR DESCRIPTION
Forgot to return the result of the `factory()` call.

Also added semicolons to the previously committed lines.