### PR TITLE
Update decorator to ractive 0.7+

### DIFF
--- a/src/Ractive-decorators-sortable.js
+++ b/src/Ractive-decorators-sortable.js
@@ -126,7 +126,7 @@ var sortableDecorator = (function ( global, factory ) {
 	dragstartHandler = function ( event ) {
 		var storage = this._ractive, lastDotIndex;
 
-		sourceKeypath = storage.keypath;
+		sourceKeypath = storage.keypath.str;
 
 		// this decorator only works with array members!
 		lastDotIndex = sourceKeypath.lastIndexOf( '.' );
@@ -156,7 +156,7 @@ var sortableDecorator = (function ( global, factory ) {
 			return;
 		}
 
-		targetKeypath = this._ractive.keypath;
+		targetKeypath = this._ractive.keypath.str;
 
 		// this decorator only works with array members!
 		lastDotIndex = targetKeypath.lastIndexOf( '.' );


### PR DESCRIPTION
```keypath```s are not string anymore. They are objects. Fix issue #19